### PR TITLE
Add fast-fail option to mocha tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Intro sprint teaching basic blockchain practices and structure",
   "main": "blockchain-intro-prompt.js",
   "scripts": {
-    "test": "mocha tests"
+    "test": "mocha -b tests"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Seeing all 40 test failures at once may be overwhelming to new students. This will just show the first test failure.